### PR TITLE
Add the screen to help user to change his PIN

### DIFF
--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/Page.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/Page.kt
@@ -10,4 +10,5 @@ object Page {
     const val SETTINGS_PICTURE = "page.settings.picture"
     const val SETTINGS_SECURITY = "page.settings.security"
     const val SETTINGS_SECURITY_PIN = "page.settings.security.pin"
+    const val SETTINGS_SECURITY_PIN_CONFIRM = "page.settings.security.pin.confirm"
 }

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/Page.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/Page.kt
@@ -9,4 +9,5 @@ object Page {
     const val SETTINGS_ACCOUNT_LINK_VERIFY = "page.settings.account.link.verify"
     const val SETTINGS_PICTURE = "page.settings.picture"
     const val SETTINGS_SECURITY = "page.settings.security"
+    const val SETTINGS_SECURITY_PIN = "page.settings.security.pin"
 }

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommand.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommand.kt
@@ -2,7 +2,6 @@ package com.wutsi.application.shell.endpoint.settings.security.command
 
 import com.wutsi.application.shell.endpoint.AbstractCommand
 import com.wutsi.application.shell.endpoint.settings.security.dto.ChangePinRequest
-import com.wutsi.application.shell.service.AccountService
 import com.wutsi.application.shell.service.URLBuilder
 import com.wutsi.flutter.sdui.Action
 import com.wutsi.flutter.sdui.enums.ActionType
@@ -14,13 +13,13 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/commands/change-pin")
 class ChangePinCommand(
-    private val service: AccountService,
     private val urlBuilder: URLBuilder,
 ) : AbstractCommand() {
     @PostMapping
     fun index(@RequestBody request: ChangePinRequest): Action =
         Action(
             type = ActionType.Route,
-            url = urlBuilder.build("settings/security/confirm-pin?pin=${request.pin}")
+            url = urlBuilder.build("settings/security/confirm-pin?pin=${request.pin}"),
+            replacement = true
         )
 }

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommand.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommand.kt
@@ -1,0 +1,26 @@
+package com.wutsi.application.shell.endpoint.settings.security.command
+
+import com.wutsi.application.shell.endpoint.AbstractCommand
+import com.wutsi.application.shell.endpoint.settings.security.dto.ChangePinRequest
+import com.wutsi.application.shell.service.AccountService
+import com.wutsi.application.shell.service.URLBuilder
+import com.wutsi.flutter.sdui.Action
+import com.wutsi.flutter.sdui.enums.ActionType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/commands/change-pin")
+class ChangePinCommand(
+    private val service: AccountService,
+    private val urlBuilder: URLBuilder,
+) : AbstractCommand() {
+    @PostMapping
+    fun index(@RequestBody request: ChangePinRequest): Action =
+        Action(
+            type = ActionType.Route,
+            url = urlBuilder.build("settings/security/confirm-pin?pin=${request.pin}")
+        )
+}

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ConfirmPinCommand.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ConfirmPinCommand.kt
@@ -1,0 +1,33 @@
+package com.wutsi.application.shell.endpoint.settings.security.command
+
+import com.wutsi.application.shell.endpoint.AbstractCommand
+import com.wutsi.application.shell.endpoint.settings.security.dto.ChangePinRequest
+import com.wutsi.application.shell.exception.PinMismatchException
+import com.wutsi.application.shell.service.AccountService
+import com.wutsi.flutter.sdui.Action
+import com.wutsi.flutter.sdui.enums.ActionType
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/commands/confirm-pin")
+class ConfirmPinCommand(
+    private val service: AccountService,
+) : AbstractCommand() {
+    @PostMapping
+    fun index(@RequestParam pin: String, @RequestBody request: ChangePinRequest): Action {
+        service.confirmPin(pin, request)
+        return Action(
+            type = ActionType.Route,
+            url = "route:/.."
+        )
+    }
+
+    @ExceptionHandler(PinMismatchException::class)
+    fun onPinMismatchException(e: PinMismatchException): Action =
+        createErrorAction(e, "prompt.error.pin-mismatch")
+}

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/dto/ChangePinRequest.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/dto/ChangePinRequest.kt
@@ -1,0 +1,5 @@
+package com.wutsi.application.shell.endpoint.settings.security.dto
+
+data class ChangePinRequest(
+    val pin: String = "",
+)

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsConfirmPINScreen.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsConfirmPINScreen.kt
@@ -1,0 +1,67 @@
+package com.wutsi.application.shell.endpoint.settings.security.screen
+
+import com.wutsi.application.shell.endpoint.AbstractQuery
+import com.wutsi.application.shell.endpoint.Page
+import com.wutsi.application.shell.endpoint.Theme
+import com.wutsi.application.shell.service.URLBuilder
+import com.wutsi.flutter.sdui.Action
+import com.wutsi.flutter.sdui.AppBar
+import com.wutsi.flutter.sdui.Column
+import com.wutsi.flutter.sdui.Container
+import com.wutsi.flutter.sdui.PinWithKeyboard
+import com.wutsi.flutter.sdui.Screen
+import com.wutsi.flutter.sdui.Text
+import com.wutsi.flutter.sdui.enums.ActionType
+import com.wutsi.flutter.sdui.enums.Alignment
+import com.wutsi.flutter.sdui.enums.TextAlignment
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/settings/security/confirm-pin")
+class SettingsConfirmPINScreen(
+    private val urlBuilder: URLBuilder
+) : AbstractQuery() {
+    @PostMapping
+    fun index(@RequestParam pin: String) = Screen(
+        id = Page.SETTINGS_SECURITY_PIN_CONFIRM,
+        appBar = AppBar(
+            elevation = 0.0,
+            backgroundColor = Theme.WHITE_COLOR,
+            foregroundColor = Theme.BLACK_COLOR,
+            title = getText("page.settings.pin-confirm.app-bar.title")
+        ),
+        child = Container(
+            alignment = Alignment.Center,
+            padding = 20.0,
+            child = Column(
+                children = listOf(
+                    Container(
+                        alignment = Alignment.TopCenter,
+                        padding = 10.0,
+                        child = Text(
+                            caption = getText("page.settings.pin-confirm.sub-title"),
+                            alignment = TextAlignment.Center,
+                            size = Theme.LARGE_TEXT_SIZE,
+                        )
+                    ),
+                    PinWithKeyboard(
+                        name = "pin",
+                        hideText = true,
+                        deleteText = getText("keyboard.delete"),
+                        maxLength = 6,
+                        action = Action(
+                            type = ActionType.Command,
+                            url = urlBuilder.build("commands/confirm-pin"),
+                            parameters = mapOf(
+                                "pin" to pin
+                            )
+                        ),
+                    ),
+                )
+            )
+        )
+    ).toWidget()
+}

--- a/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsPINScreen.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsPINScreen.kt
@@ -1,0 +1,63 @@
+package com.wutsi.application.shell.endpoint.settings.security.screen
+
+import com.wutsi.application.shell.endpoint.AbstractQuery
+import com.wutsi.application.shell.endpoint.Page
+import com.wutsi.application.shell.endpoint.Theme
+import com.wutsi.application.shell.service.URLBuilder
+import com.wutsi.flutter.sdui.Action
+import com.wutsi.flutter.sdui.AppBar
+import com.wutsi.flutter.sdui.Column
+import com.wutsi.flutter.sdui.Container
+import com.wutsi.flutter.sdui.PinWithKeyboard
+import com.wutsi.flutter.sdui.Screen
+import com.wutsi.flutter.sdui.Text
+import com.wutsi.flutter.sdui.enums.ActionType
+import com.wutsi.flutter.sdui.enums.Alignment
+import com.wutsi.flutter.sdui.enums.TextAlignment
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/settings/security/pin")
+class SettingsPINScreen(
+    private val urlBuilder: URLBuilder
+) : AbstractQuery() {
+    @PostMapping
+    fun index() = Screen(
+        id = Page.SETTINGS_SECURITY_PIN,
+        appBar = AppBar(
+            elevation = 0.0,
+            backgroundColor = Theme.WHITE_COLOR,
+            foregroundColor = Theme.BLACK_COLOR,
+            title = getText("page.settings.pin.app-bar.title")
+        ),
+        child = Container(
+            alignment = Alignment.Center,
+            padding = 20.0,
+            child = Column(
+                children = listOf(
+                    Container(
+                        alignment = Alignment.TopCenter,
+                        padding = 10.0,
+                        child = Text(
+                            caption = getText("page.settings.pin.sub-title"),
+                            alignment = TextAlignment.Center,
+                            size = Theme.LARGE_TEXT_SIZE,
+                        )
+                    ),
+                    PinWithKeyboard(
+                        name = "pin",
+                        hideText = true,
+                        deleteText = getText("keyboard.delete"),
+                        maxLength = 6,
+                        action = Action(
+                            type = ActionType.Command,
+                            url = urlBuilder.build("commands/change-pin")
+                        ),
+                    ),
+                )
+            )
+        )
+    ).toWidget()
+}

--- a/src/main/kotlin/com/wutsi/application/shell/exception/PinMismatchException.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/exception/PinMismatchException.kt
@@ -1,0 +1,3 @@
+package com.wutsi.application.shell.exception
+
+class PinMismatchException : Exception()

--- a/src/main/kotlin/com/wutsi/application/shell/service/AccountService.kt
+++ b/src/main/kotlin/com/wutsi/application/shell/service/AccountService.kt
@@ -3,15 +3,18 @@ package com.wutsi.application.shell.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.wutsi.application.shell.endpoint.settings.account.dto.SendSmsCodeRequest
 import com.wutsi.application.shell.endpoint.settings.account.dto.VerifySmsCodeRequest
+import com.wutsi.application.shell.endpoint.settings.security.dto.ChangePinRequest
 import com.wutsi.application.shell.endpoint.settings.security.dto.UpdateAccountAttributeRequest
 import com.wutsi.application.shell.entity.SmsCodeEntity
 import com.wutsi.application.shell.exception.AccountAlreadyLinkedException
 import com.wutsi.application.shell.exception.InvalidPhoneNumberException
+import com.wutsi.application.shell.exception.PinMismatchException
 import com.wutsi.application.shell.exception.SmsCodeMismatchException
 import com.wutsi.application.shell.exception.toErrorResponse
 import com.wutsi.platform.account.WutsiAccountApi
 import com.wutsi.platform.account.dto.AddPaymentMethodRequest
 import com.wutsi.platform.account.dto.PaymentMethodSummary
+import com.wutsi.platform.account.dto.SavePasswordRequest
 import com.wutsi.platform.core.logging.KVLogger
 import com.wutsi.platform.core.tracing.DeviceIdProvider
 import com.wutsi.platform.payment.PaymentMethodProvider
@@ -118,6 +121,18 @@ class AccountService(
             return tenantProvider.logo(carrier)
         }
         return null
+    }
+
+    fun confirmPin(pin: String, request: ChangePinRequest) {
+        if (pin != request.pin)
+            throw PinMismatchException()
+
+        accountApi.savePassword(
+            id = userProvider.id(),
+            request = SavePasswordRequest(
+                password = request.pin
+            )
+        )
     }
 
     fun setTransferSecured(request: UpdateAccountAttributeRequest) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,6 +1,7 @@
 keyboard.delete=Delete
 prompt.error.title=Error
 prompt.error.unexpected-error=Oops! An unexpected error has occurred. Please try again.
+prompt.error.pin-mismatch=Sorry! The PINs doesn't match.
 page.home.button.add-account=Link Account
 page.home.your-accounts=Your Accounts
 page.home.your-balance=Your Balance
@@ -33,6 +34,8 @@ page.settings.account.button.add-account=Link Account
 page.settings.picture.app-bar.title=Upload your Picture
 page.settings.pin.app-bar.title=Modify your PIN
 page.settings.pin.sub-title=Protect your account with 6 digits code
+page.settings.pin-confirm.app-bar.title=Confirm your PIN
+page.settings.pin-confirm.sub-title=Re-enter your 6 digits code
 page.settings.security.app-bar.title=Security
 page.verify-account-mobile.app-bar.title=Verify Account
 page.verify-account-mobile.sub-title=Enter the code sent to {0}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,4 @@
+keyboard.delete=Delete
 prompt.error.title=Error
 prompt.error.unexpected-error=Oops! An unexpected error has occurred. Please try again.
 page.home.button.add-account=Link Account
@@ -30,6 +31,8 @@ page.settings.account.button.cash-out=Cash Out
 page.settings.account.your-balance=Your Balance
 page.settings.account.button.add-account=Link Account
 page.settings.picture.app-bar.title=Upload your Picture
+page.settings.pin.app-bar.title=Modify your PIN
+page.settings.pin.sub-title=Protect your account with 6 digits code
 page.settings.security.app-bar.title=Security
 page.verify-account-mobile.app-bar.title=Verify Account
 page.verify-account-mobile.sub-title=Enter the code sent to {0}

--- a/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommandTest.kt
+++ b/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommandTest.kt
@@ -38,5 +38,6 @@ internal class ChangePinCommandTest : AbstractEndpointTest() {
         val action = response.body
         assertEquals(ActionType.Route, action.type)
         assertEquals("http://localhost:0/settings/security/confirm-pin?pin=${request.pin}", action.url)
+        assertEquals(true, action.replacement)
     }
 }

--- a/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommandTest.kt
+++ b/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ChangePinCommandTest.kt
@@ -1,0 +1,42 @@
+package com.wutsi.application.shell.endpoint.settings.security.command
+
+import com.wutsi.application.shell.endpoint.AbstractEndpointTest
+import com.wutsi.application.shell.endpoint.settings.security.dto.ChangePinRequest
+import com.wutsi.flutter.sdui.Action
+import com.wutsi.flutter.sdui.enums.ActionType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+import kotlin.test.assertEquals
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+internal class ChangePinCommandTest : AbstractEndpointTest() {
+    @LocalServerPort
+    val port: Int = 0
+
+    private lateinit var url: String
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+
+        url = "http://localhost:$port/commands/change-pin"
+    }
+
+    @Test
+    fun run() {
+        // WHEN
+        val request = ChangePinRequest(
+            pin = "123456"
+        )
+        val response = rest.postForEntity(url, request, Action::class.java)
+
+        // THEN
+        assertEquals(200, response.statusCodeValue)
+
+        val action = response.body
+        assertEquals(ActionType.Route, action.type)
+        assertEquals("http://localhost:0/settings/security/confirm-pin?pin=${request.pin}", action.url)
+    }
+}

--- a/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ConfirmPinCommandTest.kt
+++ b/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ConfirmPinCommandTest.kt
@@ -1,0 +1,71 @@
+package com.wutsi.application.shell.endpoint.settings.security.command
+
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.wutsi.application.shell.endpoint.AbstractEndpointTest
+import com.wutsi.application.shell.endpoint.settings.security.dto.ChangePinRequest
+import com.wutsi.flutter.sdui.Action
+import com.wutsi.flutter.sdui.enums.ActionType
+import com.wutsi.platform.account.dto.SavePasswordRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+internal class ConfirmPinCommandTest : AbstractEndpointTest() {
+    @LocalServerPort
+    val port: Int = 0
+
+    private lateinit var url: String
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+
+        url = "http://localhost:$port/commands/confirm-pin?pin=123456"
+    }
+
+    @Test
+    fun run() {
+        // WHEN
+        val request = ChangePinRequest(
+            pin = "123456"
+        )
+        val response = rest.postForEntity(url, request, Action::class.java)
+
+        // THEN
+        assertEquals(200, response.statusCodeValue)
+
+        val req = argumentCaptor<SavePasswordRequest>()
+        verify(accountApi).savePassword(eq(ACCOUNT_ID), req.capture())
+        kotlin.test.assertEquals(request.pin, req.firstValue.password)
+
+        val action = response.body
+        assertEquals(ActionType.Route, action.type)
+        assertEquals("route:/..", action.url)
+    }
+
+    @Test
+    fun passwordMismatch() {
+        // WHEN
+        val request = ChangePinRequest(
+            pin = "123456"
+        )
+        val response = rest.postForEntity(url, request, Action::class.java)
+
+        // THEN
+        assertEquals(200, response.statusCodeValue)
+
+        val req = argumentCaptor<SavePasswordRequest>()
+        verify(accountApi).savePassword(eq(ACCOUNT_ID), req.capture())
+        kotlin.test.assertEquals(request.pin, req.firstValue.password)
+
+        val action = response.body
+        assertEquals(ActionType.Route, action.type)
+        assertEquals("route:/..", action.url)
+    }
+}
+

--- a/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ConfirmPinCommandTest.kt
+++ b/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/command/ConfirmPinCommandTest.kt
@@ -68,4 +68,3 @@ internal class ConfirmPinCommandTest : AbstractEndpointTest() {
         assertEquals("route:/..", action.url)
     }
 }
-

--- a/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsConfirmPINScreenTest.kt
+++ b/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsConfirmPINScreenTest.kt
@@ -1,0 +1,28 @@
+package com.wutsi.application.shell.endpoint.settings.security.screen
+
+import com.wutsi.application.shell.endpoint.AbstractEndpointTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+internal class SettingsConfirmPINScreenTest : AbstractEndpointTest() {
+    @LocalServerPort
+    val port: Int = 0
+
+    private lateinit var url: String
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+
+        url = "http://localhost:$port/settings/security/confirm-pin?pin=1234"
+    }
+
+    @Test
+    fun index() {
+        // THEN
+        assertEndpointEquals("/screens/settings/security/confirm-pin.json", url)
+    }
+}

--- a/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsPINScreenTest.kt
+++ b/src/test/kotlin/com/wutsi/application/shell/endpoint/settings/security/screen/SettingsPINScreenTest.kt
@@ -1,0 +1,28 @@
+package com.wutsi.application.shell.endpoint.settings.security.screen
+
+import com.wutsi.application.shell.endpoint.AbstractEndpointTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+internal class SettingsPINScreenTest : AbstractEndpointTest() {
+    @LocalServerPort
+    val port: Int = 0
+
+    private lateinit var url: String
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+
+        url = "http://localhost:$port/settings/security/pin"
+    }
+
+    @Test
+    fun index() {
+        // THEN
+        assertEndpointEquals("/screens/settings/security/pin.json", url)
+    }
+}

--- a/src/test/resources/screens/settings/security/confirm-pin.json
+++ b/src/test/resources/screens/settings/security/confirm-pin.json
@@ -1,0 +1,69 @@
+{
+  "type": "Screen",
+  "attributes": {
+    "id": "page.settings.security.pin.confirm",
+    "safe": false
+  },
+  "children": [
+    {
+      "type": "Container",
+      "attributes": {
+        "alignment": "Center",
+        "padding": 20.0
+      },
+      "children": [
+        {
+          "type": "Column",
+          "attributes": {},
+          "children": [
+            {
+              "type": "Container",
+              "attributes": {
+                "alignment": "TopCenter",
+                "padding": 10.0
+              },
+              "children": [
+                {
+                  "type": "Text",
+                  "attributes": {
+                    "caption": "Re-enter your 6 digits code",
+                    "size": 18.0,
+                    "alignment": "Center"
+                  },
+                  "children": []
+                }
+              ]
+            },
+            {
+              "type": "PinWithKeyboard",
+              "attributes": {
+                "name": "pin",
+                "deleteText": "Delete",
+                "maxLength": 6,
+                "hideText": true
+              },
+              "children": [],
+              "action": {
+                "type": "Command",
+                "url": "http://localhost:0/commands/confirm-pin",
+                "parameters": {
+                  "pin": "1234"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "appBar": {
+    "type": "AppBar",
+    "attributes": {
+      "title": "Confirm your PIN",
+      "elevation": 0.0,
+      "backgroundColor": "#FFFFFF",
+      "foregroundColor": "#000000"
+    },
+    "children": []
+  }
+}

--- a/src/test/resources/screens/settings/security/pin.json
+++ b/src/test/resources/screens/settings/security/pin.json
@@ -1,0 +1,66 @@
+{
+  "type": "Screen",
+  "attributes": {
+    "id": "page.settings.security.pin",
+    "safe": false
+  },
+  "children": [
+    {
+      "type": "Container",
+      "attributes": {
+        "alignment": "Center",
+        "padding": 20.0
+      },
+      "children": [
+        {
+          "type": "Column",
+          "attributes": {},
+          "children": [
+            {
+              "type": "Container",
+              "attributes": {
+                "alignment": "TopCenter",
+                "padding": 10.0
+              },
+              "children": [
+                {
+                  "type": "Text",
+                  "attributes": {
+                    "caption": "Protect your account with 6 digits code",
+                    "size": 18.0,
+                    "alignment": "Center"
+                  },
+                  "children": []
+                }
+              ]
+            },
+            {
+              "type": "PinWithKeyboard",
+              "attributes": {
+                "name": "pin",
+                "deleteText": "Delete",
+                "maxLength": 6,
+                "hideText": true
+              },
+              "children": [],
+              "action": {
+                "type": "Command",
+                "url": "http://localhost:0/commands/change-pin"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "appBar": {
+    "type": "AppBar",
+    "attributes": {
+      "title": "Modify your PIN",
+      "elevation": 0.0,
+      "backgroundColor": "#FFFFFF",
+      "foregroundColor": "#000000"
+    },
+    "children": []
+  }
+}


### PR DESCRIPTION
Add screen to help customer to change his PIN from the Settings/Security

| Security (DONE) | Change PIN | Confirm PIN |
|-----------------|-------------|--------------|
| <img width="200" alt="Screen Shot 2021-12-10 at 10 48 59 AM" src="https://user-images.githubusercontent.com/39621277/145602019-c89db405-98d3-4caf-b746-349287292fed.png"> | <img width="200" alt="Screen Shot 2021-12-10 at 9 54 51 AM" src="https://user-images.githubusercontent.com/39621277/145594608-7881c89f-a3db-45d0-811d-fa57333b6919.png"> | <img width="200" alt="Screen Shot 2021-12-10 at 10 30 42 AM" src="https://user-images.githubusercontent.com/39621277/145599454-1058b788-f3e5-4e4b-a200-1419d4c47656.png"> |